### PR TITLE
fix: bug that jsonlds are sanitized with nuxt2.9

### DIFF
--- a/src/createMixin.ts
+++ b/src/createMixin.ts
@@ -12,7 +12,7 @@ interface JsonldConfig {
     innerHTML: string;
   }[];
   __dangerouslyDisableSanitizersByTagID?: {
-    [key: string]: 'innerHTML';
+    [key: string]: ['innerHTML'];
   };
 }
 
@@ -51,7 +51,7 @@ export default (options: Options = {}): JsonldMixin => {
           },
         ],
         __dangerouslyDisableSanitizersByTagID: {
-          [hid]: 'innerHTML',
+          [hid]: ['innerHTML'],
         },
       };
     },

--- a/test/createMixin.spec.js
+++ b/test/createMixin.spec.js
@@ -56,7 +56,7 @@ describe('with jsonld', () => {
 
     expect(mock.$options.head.call(mock)).toEqual({
       __dangerouslyDisableSanitizersByTagID: {
-        'nuxt-jsonld-8251e634': 'innerHTML',
+        'nuxt-jsonld-8251e634': ['innerHTML'],
       },
       script: [
         {
@@ -101,7 +101,7 @@ describe('with jsonld', () => {
 
       expect(mock.$options.head.call(mock)).toEqual({
         __dangerouslyDisableSanitizersByTagID: {
-          'nuxt-jsonld-a36cc3c0': 'innerHTML',
+          'nuxt-jsonld-a36cc3c0': ['innerHTML'],
         },
         script: [
           {
@@ -138,7 +138,7 @@ describe('with jsonld', () => {
 
       expect(mock.$options.head.call(mock)).toEqual({
         __dangerouslyDisableSanitizersByTagID: {
-          'nuxt-jsonld-5414b96e': 'innerHTML',
+          'nuxt-jsonld-5414b96e': ['innerHTML'],
         },
         script: [
           {
@@ -191,7 +191,7 @@ describe('hid', () => {
     expect(actual).toEqual([
       {
         __dangerouslyDisableSanitizersByTagID: {
-          'nuxt-jsonld-4e298139': 'innerHTML',
+          'nuxt-jsonld-4e298139': ['innerHTML'],
         },
         script: [
           {
@@ -203,7 +203,7 @@ describe('hid', () => {
       },
       {
         __dangerouslyDisableSanitizersByTagID: {
-          'nuxt-jsonld-90d62c9': 'innerHTML',
+          'nuxt-jsonld-90d62c9': ['innerHTML'],
         },
         script: [
           {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -81,19 +81,19 @@ describe('merge strategy', () => {
   test('object already has __dangerouslyDisableSanitizersByTagID', () => {
     const from = {
       __dangerouslyDisableSanitizersByTagID: {
-        foo: 'innerHTML',
+        foo: ['innerHTML'],
       },
     };
     const to = {
       __dangerouslyDisableSanitizersByTagID: {
-        bar: 'innerHTML',
+        bar: ['innerHTML'],
       },
     };
     const resFunc = jsonld.mergeStrategy(to, from);
     expect(resFunc()).toEqual({
       __dangerouslyDisableSanitizersByTagID: {
-        foo: 'innerHTML',
-        bar: 'innerHTML',
+        foo: ['innerHTML'],
+        bar: ['innerHTML'],
       },
     });
   });


### PR DESCRIPTION
closes #98 