### PR TITLE
Replacing the hash function

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   ],
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "schema-dts": "^0.8.2",
-    "xxhashjs": "^0.2.2"
+    "schema-dts": "^0.8.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",

--- a/src/mergeHead.ts
+++ b/src/mergeHead.ts
@@ -1,4 +1,3 @@
-import XXH from 'xxhashjs';
 import { Options } from './createMixin';
 
 interface JsonLDObject {
@@ -13,6 +12,24 @@ const getOriginalHeadObject = (that, originalHead): JsonLDObject => {
   return originalHead || null;
 };
 
+function hashCode(s: string) {
+  /**
+   * Using the java hashCode function
+   * https://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+   * https://www.thejavaprogrammer.com/what-is-hashcode-in-java/
+   */
+  let hash = 0;
+  if (s.length === 0) {
+    return hash;
+  }
+  for (let i = 0; i < s.length; i += 1) {
+    const char = s.charCodeAt(i);
+    hash = (hash << 5) - hash + char; // eslint-disable-line no-bitwise
+    hash &= hash; // eslint-disable-line no-bitwise
+  }
+  return hash;
+}
+
 const getJsonLdHeadObject = (that, jsonLdFunc: Function, space: Options['space']): JsonLDObject => {
   const jsonLd = jsonLdFunc.call(that);
   if (jsonLd === null) {
@@ -20,7 +37,7 @@ const getJsonLdHeadObject = (that, jsonLdFunc: Function, space: Options['space']
   }
 
   const minifiedString = JSON.stringify(jsonLd, null, '');
-  const hid = `nuxt-jsonld-${XXH.h32(minifiedString, 0).toString(16)}`;
+  const hid = `nuxt-jsonld-${hashCode(minifiedString).toString(16)}`;
 
   const stringifiedJson = JSON.stringify(jsonLd, null, space);
   const innerHTML = space === 0 ? stringifiedJson : `\n${stringifiedJson}\n`;

--- a/test/createMixin.spec.js
+++ b/test/createMixin.spec.js
@@ -56,11 +56,11 @@ describe('without head and with jsonld', () => {
     const mock = mockInstanceFactory();
     expect(mock.$options.head.call(mock)).toEqual({
       __dangerouslyDisableSanitizersByTagID: {
-        'nuxt-jsonld-5414b96e': ['innerHTML'],
+        'nuxt-jsonld-24692542': ['innerHTML'],
       },
       script: [
         {
-          hid: 'nuxt-jsonld-5414b96e',
+          hid: 'nuxt-jsonld-24692542',
           innerHTML: `
 {
   "@context": "http://schema.org",
@@ -114,7 +114,7 @@ describe('with head and jsonld', () => {
       const mock = mockInstanceFactory(head, { space: '\t' });
       expect(mock.$options.head.call(mock)).toEqual({
         __dangerouslyDisableSanitizersByTagID: {
-          'nuxt-jsonld-5414b96e': ['innerHTML'],
+          'nuxt-jsonld-24692542': ['innerHTML'],
         },
         title: 'title',
         script: [
@@ -122,7 +122,7 @@ describe('with head and jsonld', () => {
             src: 'script.js',
           },
           {
-            hid: 'nuxt-jsonld-5414b96e',
+            hid: 'nuxt-jsonld-24692542',
             innerHTML: `
 {
 	"@context": "http://schema.org",
@@ -155,7 +155,7 @@ describe('with head and jsonld', () => {
 
       expect(mock.$options.head.call(mock)).toEqual({
         __dangerouslyDisableSanitizersByTagID: {
-          'nuxt-jsonld-5414b96e': ['innerHTML'],
+          'nuxt-jsonld-24692542': ['innerHTML'],
         },
         title: 'title',
         script: [
@@ -163,7 +163,7 @@ describe('with head and jsonld', () => {
             src: 'script.js',
           },
           {
-            hid: 'nuxt-jsonld-5414b96e',
+            hid: 'nuxt-jsonld-24692542',
             innerHTML: `{"@context":"http://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https://example.com/"}},{"@type":"ListItem","position":2,"item":{"@id":"https://example.com/foo/"}}]}`,
             type: 'application/ld+json',
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,11 +2094,6 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-cuint@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
-  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
-
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -8143,13 +8138,6 @@ xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
-
-xxhashjs@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
-  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
-  dependencies:
-    cuint "^0.2.2"
 
 y18n@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
The hash function adds 30kb+ (parsed size) to the bundle:
![image](https://user-images.githubusercontent.com/2091290/118242447-05cfb000-b4a6-11eb-823d-fb6462607067.png)


The hashCode function from java that I replaced it with is probably far from collision free, but I do not think that this is important here.