### PR TITLE
fix: update nuxt version constraint

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -11,7 +11,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-jsonld',
     compatibility: {
-      nuxt: '^3.0.0',
+      nuxt: '^3.0.0-rc.8',
       bridge: false,
     },
   },


### PR DESCRIPTION
In https://github.com/nuxt/framework/pull/7116 we made a breaking change allowing modules to use RC constraints. This PR fixes this.