### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/packages/nuxt-jsonld/src/module.ts
+++ b/packages/nuxt-jsonld/src/module.ts
@@ -28,7 +28,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
 });
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomOptions {
     jsonld?: JsonLDFunc;
   }


### PR DESCRIPTION

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.